### PR TITLE
Remove /ping from deeptrace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expresso/app",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Basic @expresso express boilerplate",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/middlewares/deep-trace.ts
+++ b/src/middlewares/deep-trace.ts
@@ -1,4 +1,5 @@
 const DeepTrace = require('deeptrace-express')
+import { Request, Response, NextFunction } from 'express'
 
 // TODO: Make this reflect the whole possibility of deepstream configuration options
 export interface IDeepTraceOptions {
@@ -13,5 +14,8 @@ export interface IDeepTraceOptions {
  * @param config - Deepstream's configuration options
  */
 export function factory (config: IDeepTraceOptions) {
-  return DeepTrace.middleware(config)
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.path !== '/ping') return DeepTrace.middleware(config)(req, res, next)
+    return next()
+  }
 }


### PR DESCRIPTION
Add check that prevents `GET /ping` requests from being traced by deeptrace